### PR TITLE
fix: update local-quickstart.md

### DIFF
--- a/content/guides/local-quickstart.md
+++ b/content/guides/local-quickstart.md
@@ -79,8 +79,8 @@ The requirements for this quickstart depend on your operating system.
         On __Linux__, you may need to increase your system's open/watched file limits.
 
         1. Modify `/etc/sysctl.conf` to include the following lines:
-            - `fs.inotify.max_user_instances = 1280`
-            - `fs.inotify.max_user_watches = 655360`
+            - `fs.inotify.max_user_instances=1280`
+            - `fs.inotify.max_user_watches=655360`
         2. Reload sysctl configs by running `sudo sysctl -p`
 
     ??? info "Homebrew for Linux"
@@ -353,7 +353,7 @@ git clone -b main https://github.com/deployKF/deployKF.git ./deploykf
 chmod +x ./deploykf/argocd-plugin/install_argocd.sh
 
 # run the install script
-# WARNING: this will install into your current kubectl context
+# WARNING: this will install into ARGOCD_NAMESPACE (default "argocd")
 bash ./deploykf/argocd-plugin/install_argocd.sh
 ```
 

--- a/content/guides/local-quickstart.md
+++ b/content/guides/local-quickstart.md
@@ -79,8 +79,8 @@ The requirements for this quickstart depend on your operating system.
         On __Linux__, you may need to increase your system's open/watched file limits.
 
         1. Modify `/etc/sysctl.conf` to include the following lines:
-            - `fs.inotify.max_user_instances=1280`
-            - `fs.inotify.max_user_watches=655360`
+            - `fs.inotify.max_user_instances = 1280`
+            - `fs.inotify.max_user_watches = 655360`
         2. Reload sysctl configs by running `sudo sysctl -p`
 
     ??? info "Homebrew for Linux"


### PR DESCRIPTION
* Invalid sysctl assignment (space not allowed, so copy paste fails)

* install_argocd.sh default namespace is argocd, not current-context due to use of ENV

<!-- 
⚠️ please review https://github.com/deployKF/website/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

Please remember:
 - use a semantic title for your pull request (most likely "docs: xxxxx", see contributing guide)
 - sign your commits (see contributing guide)
-->