### PR TITLE
docs: map label for externallinks under deploykf_dashboards

### DIFF
--- a/content/guides/platform/deploykf-dashboard.md
+++ b/content/guides/platform/deploykf-dashboard.md
@@ -30,7 +30,7 @@ deploykf_core:
   deploykf_dashboard:
     navigation:
       externalLinks:
-        - name: "deployKF Website"
+        - text: "deployKF Website"
           url: "https://deployKF.org"
           icon: "launch"
 ```


### PR DESCRIPTION
* change map label from Name to Text as required here: 
https://github.com/deployKF/deployKF/blob/0c8caf9180736faaea3e686f7bb0335507a505b8/generator/templates/manifests/deploykf-core/deploykf-dashboard/values.yaml#L130
